### PR TITLE
Correctly determine 32bit/64bit

### DIFF
--- a/inject.c
+++ b/inject.c
@@ -223,7 +223,7 @@ static kern_return_t get_stuff(task_t task, cpu_type_t *cputype, struct addr_bun
 
 #if defined(__i386__) || defined(__x86_64__) || defined(__ppc__)
     // Try to guess whether the process is 64-bit,
-    bool proc64 = info.all_image_info_addr > 0;
+    bool proc64 = info.all_image_info_addr > 0xffffffff;
 #else
     bool proc64 = false;
 #endif


### PR DESCRIPTION
We talked about this on IRC. This fixes issues with distinguishing between 32-bit targets and 64-bit targets.
